### PR TITLE
Import @Enum annotation

### DIFF
--- a/lib/Doctrine/ORM/Mapping/ManyToOne.php
+++ b/lib/Doctrine/ORM/Mapping/ManyToOne.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\ORM\Mapping;
 
 use Attribute;
+use Doctrine\Common\Annotations\Annotation\Enum;
 use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**


### PR DESCRIPTION
Fix:
[Semantical Error] The annotation "@Enum" in property Doctrine\ORM\Mapping\ManyToOne::$fetch was never imported. Did you maybe forget to add a "use" statement for this annotation?